### PR TITLE
[IDINFRA-1998] feat(service): add additionalPorts if need ports more than 1 port

### DIFF
--- a/base/templates/service.yaml
+++ b/base/templates/service.yaml
@@ -14,7 +14,13 @@ spec:
   ports:
     - port: {{ .Values.service.srcPort }}
       targetPort: {{ .Values.service.dstPort }}
-      protocol: TCP
-      name: {{ .Values.service.name | default "http" }}
+      protocol: {{ default "TCP" .Values.service.protocol }}
+      name: {{ .Values.service.name | default "http" }}    
+    {{- range $additionalPortIndex, $additionalPort := .Values.service.additionalPorts }}
+    - port: {{ $additionalPort.srcPort }}
+      targetPort: {{ $additionalPort.dstPort }}
+      protocol: {{ default "TCP" $additionalPort.protocol }}
+      name: {{ default "http" $additionalPort.name }}    
+    {{- end }}
   selector:
     {{- include "base.selectorLabels" . | nindent 4 }}

--- a/base/templates/service.yaml
+++ b/base/templates/service.yaml
@@ -20,7 +20,7 @@ spec:
     - port: {{ $additionalPort.srcPort }}
       targetPort: {{ $additionalPort.dstPort }}
       protocol: {{ default "TCP" $additionalPort.protocol }}
-      name: {{ default "http" $additionalPort.name }}    
+      name: {{ required ".Values.service.additionalPorts[].name is required and cannot be same with another port name" $additionalPort.name }}    
     {{- end }}
   selector:
     {{- include "base.selectorLabels" . | nindent 4 }}

--- a/base/values.yaml
+++ b/base/values.yaml
@@ -215,7 +215,7 @@ service:
   #   - srcPort: 443
   #     dstPort: 443
   #     protocol: TCP #default TCP
-  #     name: https #default http
+  #     name: https #required and cannot be same with another port name
   additionalPorts: []
 
 ## End of service.yaml

--- a/base/values.yaml
+++ b/base/values.yaml
@@ -205,6 +205,18 @@ service:
   srcPort: 80
   # name: grpc #default http
   dstPort: 80
+  # protocol name of port
+  # e.g. 
+  # protocol: TCP
+  protocol: ""
+  # Optional param for adding additional ports more than 1 port
+  # e.g. 
+  # additionalPorts: 
+  #   - srcPort: 443
+  #     dstPort: 443
+  #     protocol: TCP #default TCP
+  #     name: https #default http
+  additionalPorts: []
 
 ## End of service.yaml
 


### PR DESCRIPTION
Jira Ticket: https://99dotco.atlassian.net/browse/IDINFRA-1961

e.g. result:
- if we don't add values to the `additionalPorts` parameter, then the result of the `helm template` will be like this.
![image](https://user-images.githubusercontent.com/37339379/159457184-47057240-0c72-4378-9891-913dff2d92a5.png)
- but, if we add values to the `additionalPorts` parameter, e.g. this values: 
  ```
  service:
    additionalPorts: 
      - srcPort: 443
        dstPort: 443
        protocol: TCP #default TCP
        name: https #required and cannot be same with another port name
      - srcPort: 10001
        dstPort: 10001
        name: grpc #required and cannot be same with another port name
  ```
  the result `helm template` become like this.
  ![image](https://user-images.githubusercontent.com/37339379/159457440-97c05a75-d1d2-4328-928d-7cbb71d1630f.png)