### PR TITLE
[IDDEVOPS-8] feat(base): improve helm charts base to cover implement distinaitonrule & virtualservice istio

### DIFF
--- a/base/Chart.yaml
+++ b/base/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/base/templates/virtualservice.yaml
+++ b/base/templates/virtualservice.yaml
@@ -5,11 +5,25 @@ metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
+  {{- if .Values.virtualService.gateways }}
+  {{- with .Values.virtualService.gateways }}
+  gateways:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
+  gateways:
+    - mesh
+  {{- end }}
   hosts:
-  - {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ .Release.Name }}
   http:
-  - route:
-    - destination:
-        host: {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
-        subset: v1
+    - route:
+        - destination:
+            host: {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
+            subset: v1
+      {{- with .Values.virtualService.retries }}
+      retries:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/base/values.yaml
+++ b/base/values.yaml
@@ -248,6 +248,11 @@ ingress:
 ## Istio Config
 virtualService:
   enabled: true
+  gateways: []
+  retries:
+    attempts: 3
+    perTryTimeout: 5s
+    retryOn: gateway-error,connect-failure,refused-stream
 destinationRule:
   enabled: true
   loadBalanceMode: LEAST_CONN #LoadBalancing algorithm, ROUND_ROBIN etc


### PR DESCRIPTION
Related Jira Task: https://99dotco.atlassian.net/browse/IDDEVOPS-8

e.g. actual result from this improvement
```
# Source: base/templates/destinationrules.yaml
apiVersion: networking.istio.io/v1beta1
kind: DestinationRule
metadata:
  name: graphql
  namespace: default
spec:
  host: graphql.default.svc.cluster.local
  subsets:
  - labels:
      version: env-name
    name: v1
    trafficPolicy:
      portLevelSettings:
      - port:
          number: 80
        loadBalancer:
          simple: LEAST_CONN
---
# Source: base/templates/virtualservice.yaml
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  name: graphql
  namespace: default
spec:
  gateways:
    - mesh
  hosts:
    - graphql.default.svc.cluster.local
    - graphql
  http:
    - route:
        - destination:
            host: graphql.default.svc.cluster.local
            subset: v1
      retries:
        attempts: 3
        perTryTimeout: 5s
        retryOn: gateway-error,connect-failure,refused-stream
```