### PR TITLE
[IDDEVOPS-8] feat(base): update VS Istio template to support custom hosts

### DIFF
--- a/base/Chart.yaml
+++ b/base/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/base/templates/virtualservice.yaml
+++ b/base/templates/virtualservice.yaml
@@ -14,9 +14,16 @@ spec:
   gateways:
     - mesh
   {{- end }}
+  {{- if .Values.virtualService.hosts }}
+  {{- with .Values.virtualService.hosts }}
+  hosts:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
   hosts:
     - {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
     - {{ .Release.Name }}
+  {{- end }}
   http:
     - route:
         - destination:

--- a/base/values.yaml
+++ b/base/values.yaml
@@ -249,6 +249,7 @@ ingress:
 virtualService:
   enabled: true
   gateways: []
+  hosts: []
   retries:
     attempts: 3
     perTryTimeout: 5s


### PR DESCRIPTION
Results manifest if values are not supplied (using default values):
```
# Source: base/templates/virtualservice.yaml
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  name: customerweb
  namespace: rumah123portal-develop
spec:
  gateways:
    - mesh
  hosts:
    - customerweb.rumah123portal-develop.svc.cluster.local
    - customerweb
  http:
    - route:
        - destination:
            host: customerweb.rumah123portal-develop.svc.cluster.local
            subset: v1
      retries:
        attempts: 3
        perTryTimeout: 5s
        retryOn: gateway-error,connect-failure,refused-stream
```

Results manifest if values are supplied (e.g `hosts: ['*']`):
```
# Source: base/templates/virtualservice.yaml
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  name: router
  namespace: rumah123portal-develop
spec:
  gateways:
    - rumah123portal
  hosts:
    - '*'
  http:
    - route:
        - destination:
            host: router.rumah123portal-develop.svc.cluster.local
            subset: v1
      retries:
        attempts: 3
        perTryTimeout: 5s
        retryOn: gateway-error,connect-failure,refused-stream
```