### PR TITLE
[IDDEVOPS-8] feat(base): add timeout, customHTTPRoutes, and extrasSpec for service required custom Istio VirtualServices

### DIFF
--- a/base/Chart.yaml
+++ b/base/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6-rc1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/base/templates/virtualservice.yaml
+++ b/base/templates/virtualservice.yaml
@@ -24,6 +24,12 @@ spec:
     - {{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local
     - {{ .Release.Name }}
   {{- end }}
+  {{- if .Values.virtualService.customHTTPRoutes }}
+  {{- with .Values.virtualService.customHTTPRoutes }}
+  http:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- else }}
   http:
     - route:
         - destination:
@@ -36,4 +42,8 @@ spec:
       {{- with .Values.virtualService.timeout }}
       timeout: {{ . }}
       {{- end }}
+  {{- end }}
+  {{- with .Values.virtualService.extrasSpec }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
 {{- end }}

--- a/base/templates/virtualservice.yaml
+++ b/base/templates/virtualservice.yaml
@@ -33,4 +33,7 @@ spec:
       retries:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.virtualService.timeout }}
+      timeout: {{ . }}
+      {{- end }}
 {{- end }}

--- a/base/values.yaml
+++ b/base/values.yaml
@@ -255,6 +255,8 @@ virtualService:
     perTryTimeout: 5s
     retryOn: gateway-error,connect-failure,refused-stream
   timeout: ""
+  customHTTPRoutes: [] # https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRoute
+  extrasSpec: {} # https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService
 destinationRule:
   enabled: true
   loadBalanceMode: LEAST_CONN #LoadBalancing algorithm, ROUND_ROBIN etc

--- a/base/values.yaml
+++ b/base/values.yaml
@@ -256,7 +256,30 @@ virtualService:
     retryOn: gateway-error,connect-failure,refused-stream
   timeout: ""
   customHTTPRoutes: [] # https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRoute
+    # - route:
+    #     - destination:
+    #         host: api-primary
+    #       weight: 100
+    #     - destination:
+    #         host: api-canary
+    #       weight: 0
+    #   timeout: 10s
   extrasSpec: {} # https://istio.io/latest/docs/reference/config/networking/virtual-service/#VirtualService
+    # tls:
+    #   - match:
+    #     - port: 443
+    #       sniHosts:
+    #       - login.bookinfo.com
+    #     route:
+    #     - destination:
+    #         host: login.prod.svc.cluster.local
+    #   - match:
+    #     - port: 443
+    #       sniHosts:
+    #       - reviews.bookinfo.com
+    #     route:
+    #     - destination:
+    #         host: reviews.prod.svc.cluster.local
 destinationRule:
   enabled: true
   loadBalanceMode: LEAST_CONN #LoadBalancing algorithm, ROUND_ROBIN etc

--- a/base/values.yaml
+++ b/base/values.yaml
@@ -254,6 +254,7 @@ virtualService:
     attempts: 3
     perTryTimeout: 5s
     retryOn: gateway-error,connect-failure,refused-stream
+  timeout: ""
 destinationRule:
   enabled: true
   loadBalanceMode: LEAST_CONN #LoadBalancing algorithm, ROUND_ROBIN etc


### PR DESCRIPTION
Results manifest if values are not supplied (using default values):
```
# Source: base/templates/virtualservice.yaml
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  name: api
  namespace: rumah123portal-develop
spec:
  gateways:
    - mesh
  hosts:
    - api.rumah123portal-develop.svc.cluster.local
    - api
  http:
    - route:
        - destination:
            host: api.rumah123portal-develop.svc.cluster.local
            subset: v1
      retries:
        attempts: 3
        perTryTimeout: 5s
        retryOn: gateway-error,connect-failure,refused-stream
      timeout: 10s
```
Results manifest if values are supplied:
e.g. values:
```
virtualService:
  enabled: true
  timeout: 10s
  customHTTPRoutes:
    - route:
        - destination:
            host: api-primary
          weight: 100
        - destination:
            host: api-canary
          weight: 0
      timeout: 10s
  extrasSpec:
    tls:
      - match:
        - port: 443
          sniHosts:
          - login.bookinfo.com
        route:
        - destination:
            host: login.prod.svc.cluster.local
      - match:
        - port: 443
          sniHosts:
          - reviews.bookinfo.com
        route:
        - destination:
            host: reviews.prod.svc.cluster.local
```
Results
```
# Source: base/templates/virtualservice.yaml
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  name: api
  namespace: rumah123portal-develop
spec:
  gateways:
    - mesh
  hosts:
    - api.rumah123portal-develop.svc.cluster.local
    - api
  http:
    - route:
      - destination:
          host: api-primary
        weight: 100
      - destination:
          host: api-canary
        weight: 0
      timeout: 10s
  tls:
  - match:
    - port: 443
      sniHosts:
      - login.bookinfo.com
    route:
    - destination:
        host: login.prod.svc.cluster.local
  - match:
    - port: 443
      sniHosts:
      - reviews.bookinfo.com
    route:
    - destination:
        host: reviews.prod.svc.cluster.local
```