### PR TITLE
feat(base): change default values to empty retries policy

### DIFF
--- a/base/Chart.yaml
+++ b/base/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7
+version: 0.1.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/base/values.yaml
+++ b/base/values.yaml
@@ -250,10 +250,10 @@ virtualService:
   enabled: true
   gateways: []
   hosts: []
-  retries:
-    attempts: 3
-    perTryTimeout: 60s
-    retryOn: gateway-error,connect-failure,refused-stream
+  retries: {}
+    # attempts: 3
+    # perTryTimeout: 60s
+    # retryOn: gateway-error,connect-failure,refused-stream
   timeout: ""
   customHTTPRoutes: [] # https://istio.io/latest/docs/reference/config/networking/virtual-service/#HTTPRoute
     # - route:


### PR DESCRIPTION
e.g. generated result if using default values :
```
# Source: base/templates/virtualservice.yaml
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  name: customerweb
  namespace: rumah23portal-prod
spec:
  gateways:
    - mesh
  hosts:
    - customerweb.rumah23portal-prod.svc.cluster.local
    - customerweb
  http:
    - route:
        - destination:
            host: customerweb.rumah23portal-prod.svc.cluster.local
            subset: v1
```

e.g. generated result if values using custom retries values :
````
# Source: base/templates/virtualservice.yaml
apiVersion: networking.istio.io/v1beta1
kind: VirtualService
metadata:
  name: home
  namespace: rumah23portal-prod
spec:
  gateways:
    - mesh
  hosts:
    - home.rumah23portal-prod.svc.cluster.local
    - home
  http:
    - route:
        - destination:
            host: home.rumah23portal-prod.svc.cluster.local
            subset: v1
      retries:
        attempts: 2
        perTryTimeout: 15s
        retryOn: gateway-error,reset,connect-failure,refused-stream
````