### PR TITLE
feat(base-job): apply custom imagePullSecrets feature

### DIFF
--- a/base-job/Chart.yaml
+++ b/base-job/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for K8s Job and CronJobs
 
 type: application
 
-version: 0.1.0
-appVersion: "1.16.0"
+version: 0.2.0
+appVersion: "1.17.0"
 
 keywords:
   - cron

--- a/base-job/templates/_helpers.tpl
+++ b/base-job/templates/_helpers.tpl
@@ -154,6 +154,13 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{- define "job.imagePullSecrets.tpl" -}}
+{{- with .imagePullSecrets }}
+  imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
 {{- define "job.isCron.tpl" -}}
 {{- if .values.cronJob.enabled -}}
 cron: {{ .job.name }}
@@ -186,6 +193,7 @@ spec:
             {{- include "job.volumemounts.tpl" $job | indent 10}}
           restartPolicy: {{ $job.restartPolicy }}
           {{- include "job.volumes.tpl" $job | indent 8}}
+          {{- include "job.imagePullSecrets.tpl" $job | indent 8}}
         {{- include "job.nodeSelector.tpl" $job | indent 8}}
         {{- include "job.tolerations.tpl" $job | indent 8}}
         {{- include "job.affinity.tpl" $job | indent 8}}

--- a/base-job/values.yaml
+++ b/base-job/values.yaml
@@ -33,8 +33,9 @@ jobs:
       repository: asia.gcr.io/core-v3-283604/99-lmp
       tag: detector-develop-9f4baf2-2110010945
       imagePullPolicy: IfNotPresent
-      imagePullSecrets:
-        - name: gcr-json-key
+    # Custome Image Pull secrets
+    imagePullSecrets: []
+      # - name: gcr-json-key
     # the container resources
     resources:
       limits:


### PR DESCRIPTION
---
e.g we have this values.yaml
<details>
  <summary>values.yaml</summary>

  ```yaml
  # Reference values https://github.com/urbanindo/99-charts 
  
  # Job Type Selector
  cronJob:
    enabled: true
  staticJob:
    enabled: false
  jobs:
    - name: main
      image:
        repository: asia.gcr.io/nnco-id-091322/regional-core
        tag: pr2srdetector.prod-f707e2a-230307025028 # {"$imagepolicy": "regional-core-prod:regionalcore-pr2srdetector:tag"}
        imagePullPolicy: IfNotPresent
        imagePullSecrets:
          - name: gcr-json-key
      resources:
        limits:
          cpu: 200m
          memory: 256Mi
        requests:
          cpu: 200m
          memory: 256Mi
      schedule: "0 * * * *"
      failedJobsHistoryLimit: 1
      successfulJobsHistoryLimit: 1
      concurrencyPolicy: Forbid
      suspend: false
      restartPolicy: Never
      backoffLimit: 0
      command:
        - /bin/sh
        - -c
        - ./app
      volumeMounts:
        - name: regionalcore-ini-conf
          subPath: regcore.ini
          mountPath: /root/regcore.ini
      volumes:
        - name: regionalcore-ini-conf
          configMap:
            name: regionalcore-ini-conf
            items:
              - key: regcore.ini
                path: regcore.ini
      envFrom:
        - secretRef:
            name: regionalcore-env
      annotations:
        sidecar.istio.io/inject: "false"
        secret.reloader.stakater.com/reload: "regionalcore-env"
        configmap.reloader.stakater.com/reload: "regionalcore-ini-conf"
      serviceAccount: {}
      nodeSelector: {}
      tolerations: []
      affinity: {}
  ```
</details>

result before helm updated
<details>
  <summary>cronjob.yaml</summary>
  
  ```yaml
  ---
  # Source: base-job/templates/cronjob.yaml
  apiVersion: batch/v1beta1
  kind: CronJob
  metadata:
    name: "pr2srdetector-main"
    namespace: default
    labels:
      app: "pr2srdetector-main"
      version: "demo-1"
      chart: "base-job-0.1.0"
  spec:
    schedule: "0 * * * *"
    failedJobsHistoryLimit: 1
    successfulJobsHistoryLimit: 1
    concurrencyPolicy: Forbid
    suspend: false
    jobTemplate:    
      spec:
            template:
              metadata:
                labels:
                  app: pr2srdetector
                  version: "demo-1"
                  cron: main
                  type: "cronjob"        
                annotations:
                  configmap.reloader.stakater.com/reload: regionalcore-ini-conf
                  secret.reloader.stakater.com/reload: regionalcore-env
                  sidecar.istio.io/inject: "false"
              spec:
                containers:
                - image: "asia.gcr.io/nnco-id-091322/regional-core:pr2srdetector.prod-f707e2a-230307025028"
                  imagePullPolicy: IfNotPresent
                  name: main                    
                  envFrom:
                  - secretRef:
                      name: regionalcore-env          
                  command:
                  - /bin/sh
                  - -c
                  - ./app                    
                  resources:
                    limits:
                      cpu: 200m
                      memory: 256Mi
                    requests:
                      cpu: 200m
                      memory: 256Mi          
                  volumeMounts:
                  - mountPath: /root/regcore.ini
                    name: regionalcore-ini-conf
                    subPath: regcore.ini
                restartPolicy: Never        
                volumes:
                - configMap:
                    items:
                    - key: regcore.ini
                      path: regcore.ini
                    name: regionalcore-ini-conf
                  name: regionalcore-ini-conf                        
            backoffLimit: 0
  ---
  # Source: base-job/templates/tests/test-connection.yaml
  apiVersion: v1
  kind: Pod
  metadata:
    name: "pr2srdetector-base-job-test-connection"
    labels:
      helm.sh/chart: base-job-0.1.0
      app.kubernetes.io/name: base-job
      app.kubernetes.io/instance: pr2srdetector
      app.kubernetes.io/version: "1.16.0"
      app.kubernetes.io/managed-by: Helm
    annotations:
      "helm.sh/hook": test
  spec:
    containers:
      - name: wget
        image: busybox
        command: ['wget']
        args: ['pr2srdetector-base-job:80']
    restartPolicy: Never
  ```
</details>

result after helm updated
<details>
  <summary>cronjob.yaml</summary>
  
  ```yaml
  ---
  # Source: base-job/templates/cronjob.yaml
  apiVersion: batch/v1beta1
  kind: CronJob
  metadata:
    name: "pr2srdetector-main"
    namespace: default
    labels:
      app: "pr2srdetector-main"
      version: "demo-1"
      chart: "base-job-0.1.0"
  spec:
    schedule: "0 * * * *"
    failedJobsHistoryLimit: 1
    successfulJobsHistoryLimit: 1
    concurrencyPolicy: Forbid
    suspend: false
    jobTemplate:    
      spec:
            template:
              metadata:
                labels:
                  app: pr2srdetector
                  version: "demo-1"
                  cron: main
                  type: "cronjob"        
                annotations:
                  configmap.reloader.stakater.com/reload: regionalcore-ini-conf
                  secret.reloader.stakater.com/reload: regionalcore-env
                  sidecar.istio.io/inject: "false"
              spec:
                containers:
                - image: "asia.gcr.io/nnco-id-091322/regional-core:pr2srdetector.prod-f707e2a-230307025028"
                  imagePullPolicy: IfNotPresent
                  name: main                    
                  envFrom:
                  - secretRef:
                      name: regionalcore-env          
                  command:
                  - /bin/sh
                  - -c
                  - ./app                    
                  resources:
                    limits:
                      cpu: 200m
                      memory: 256Mi
                    requests:
                      cpu: 200m
                      memory: 256Mi          
                  volumeMounts:
                  - mountPath: /root/regcore.ini
                    name: regionalcore-ini-conf
                    subPath: regcore.ini
                restartPolicy: Never        
                volumes:
                - configMap:
                    items:
                    - key: regcore.ini
                      path: regcore.ini
                    name: regionalcore-ini-conf
                  name: regionalcore-ini-conf                                
            backoffLimit: 0
  ---
  # Source: base-job/templates/tests/test-connection.yaml
  apiVersion: v1
  kind: Pod
  metadata:
    name: "pr2srdetector-base-job-test-connection"
    labels:
      helm.sh/chart: base-job-0.1.0
      app.kubernetes.io/name: base-job
      app.kubernetes.io/instance: pr2srdetector
      app.kubernetes.io/version: "1.16.0"
      app.kubernetes.io/managed-by: Helm
    annotations:
      "helm.sh/hook": test
  spec:
    containers:
      - name: wget
        image: busybox
        command: ['wget']
        args: ['pr2srdetector-base-job:80']
    restartPolicy: Never
  ```
</details>
still same and will not make breaking changes  

---  
but, after we changes the values.yaml become like this
<details>
  <summary>values.yaml</summary>
  
  ```yaml
  # Reference values https://github.com/urbanindo/99-charts
  
  # Job Type Selector
  cronJob:
    enabled: true
  staticJob:
    enabled: false
  jobs:
    - name: main
      image:
        repository: asia.gcr.io/nnco-id-091322/regional-core
        tag: pr2srdetector.prod-f707e2a-230307025028 # {"$imagepolicy": "regional-core-prod:regionalcore-pr2srdetector:tag"}
        imagePullPolicy: IfNotPresent
      imagePullSecrets:
        - name: gcr-json-key
      resources:
        limits:
          cpu: 200m
          memory: 256Mi
        requests:
          cpu: 200m
          memory: 256Mi
      schedule: "0 * * * *"
      failedJobsHistoryLimit: 1
      successfulJobsHistoryLimit: 1
      concurrencyPolicy: Forbid
      suspend: false
      restartPolicy: Never
      backoffLimit: 0
      command:
        - /bin/sh
        - -c
        - ./app
      volumeMounts:
        - name: regionalcore-ini-conf
          subPath: regcore.ini
          mountPath: /root/regcore.ini
      volumes:
        - name: regionalcore-ini-conf
          configMap:
            name: regionalcore-ini-conf
            items:
              - key: regcore.ini
                path: regcore.ini
      envFrom:
        - secretRef:
            name: regionalcore-env
      annotations:
        sidecar.istio.io/inject: "false"
        secret.reloader.stakater.com/reload: "regionalcore-env"
        configmap.reloader.stakater.com/reload: "regionalcore-ini-conf"
      serviceAccount: {}
      nodeSelector: {}
      tolerations: []
      affinity: {}
  ```
</details>
the results changes become like this
<details>
  <summary>cronjob.yaml</summary>
  
  ```yaml
  ---
  # Source: base-job/templates/cronjob.yaml
  apiVersion: batch/v1beta1
  kind: CronJob
  metadata:
    name: "pr2srdetector-main"
    namespace: default
    labels:
      app: "pr2srdetector-main"
      version: "demo-1"
      chart: "base-job-0.1.0"
  spec:
    schedule: "0 * * * *"
    failedJobsHistoryLimit: 1
    successfulJobsHistoryLimit: 1
    concurrencyPolicy: Forbid
    suspend: false
    jobTemplate:    
      spec:
            template:
              metadata:
                labels:
                  app: pr2srdetector
                  version: "demo-1"
                  cron: main
                  type: "cronjob"        
                annotations:
                  configmap.reloader.stakater.com/reload: regionalcore-ini-conf
                  secret.reloader.stakater.com/reload: regionalcore-env
                  sidecar.istio.io/inject: "false"
              spec:
                containers:
                - image: "asia.gcr.io/nnco-id-091322/regional-core:pr2srdetector.prod-f707e2a-230307025028"
                  imagePullPolicy: IfNotPresent
                  name: main                    
                  envFrom:
                  - secretRef:
                      name: regionalcore-env          
                  command:
                  - /bin/sh
                  - -c
                  - ./app                    
                  resources:
                    limits:
                      cpu: 200m
                      memory: 256Mi
                    requests:
                      cpu: 200m
                      memory: 256Mi          
                  volumeMounts:
                  - mountPath: /root/regcore.ini
                    name: regionalcore-ini-conf
                    subPath: regcore.ini
                restartPolicy: Never        
                volumes:
                - configMap:
                    items:
                    - key: regcore.ini
                      path: regcore.ini
                    name: regionalcore-ini-conf
                  name: regionalcore-ini-conf        
                imagePullSecrets:
                - name: gcr-json-key                        
            backoffLimit: 0
  ---
  # Source: base-job/templates/tests/test-connection.yaml
  apiVersion: v1
  kind: Pod
  metadata:
    name: "pr2srdetector-base-job-test-connection"
    labels:
      helm.sh/chart: base-job-0.1.0
      app.kubernetes.io/name: base-job
      app.kubernetes.io/instance: pr2srdetector
      app.kubernetes.io/version: "1.16.0"
      app.kubernetes.io/managed-by: Helm
    annotations:
      "helm.sh/hook": test
  spec:
    containers:
      - name: wget
        image: busybox
        command: ['wget']
        args: ['pr2srdetector-base-job:80']
    restartPolicy: Never
  ```
</details>