### PR TITLE
feat(base): add dnsConfig support to deployment template

### DIFF
--- a/base/templates/deployment.yaml
+++ b/base/templates/deployment.yaml
@@ -104,6 +104,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/base/values.yaml
+++ b/base/values.yaml
@@ -209,6 +209,15 @@ tolerations: []
 
 affinity: {}
 
+# dnsConfig allows overriding pod DNS resolver settings.
+# Common use: set ndots:1 to prevent DNS search-domain amplification on external hostnames.
+# Example:
+# dnsConfig:
+#   options:
+#     - name: ndots
+#       value: "1"
+dnsConfig: {}
+
 ## End of deployment.yaml
 
 ## service.yaml


### PR DESCRIPTION
Allow services to override pod DNS resolver settings via values.yaml. Renders spec.dnsConfig when the value is non-empty (opt-in, defaults to {}).

Use case: ndots:1 to stop DNS search-domain amplification on external hostnames — fixes the DNS throttling incident 2026-05-27 on portal-img where ndots:5 was generating ~490 DNS queries per 30s burst.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional DNS configuration capability for pods, allowing customization of DNS resolver settings including ndots and other pod-level DNS parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/urbanindo/99-charts/pull/108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->